### PR TITLE
Fix wrong abc.ABCMeta reference, closes#4

### DIFF
--- a/src/microesb.py
+++ b/src/microesb.py
@@ -16,10 +16,9 @@ import esbconfig
 from microesb.transformer import JSONTransformer
 
 
-class BaseHandler(JSONTransformer):
+class BaseHandler(JSONTransformer, metaclass=abc.ABCMeta):
     """ Abstract Base Class (ABC) Meta Class.
     """
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self):
         """


### PR DESCRIPTION
Reference correct by argument passing.