### PR TITLE
Fix ABCmeta class init

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -316,9 +316,9 @@ design aspects have been selected.
 
 .. code-block:: python
 
-    class Cert(microesb.ClassHandler):
+    import abc
 
-        __metaclass__ = abc.ABCMeta
+    class Cert(microesb.ClassHandler,  metaclass=abc.ABCMeta):
 
         def __init__(self):
             super().__init__()

--- a/example/02-pki-management/service_implementation.py
+++ b/example/02-pki-management/service_implementation.py
@@ -3,9 +3,7 @@ import abc
 from microesb import microesb
 
 
-class Cert(microesb.ClassHandler):
-
-    __metaclass__ = abc.ABCMeta
+class Cert(microesb.ClassHandler, metaclass=abc.ABCMeta):
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Move `__metaclass__ = abc.ABCMeta` from constructor to class init method (`metaclass=abc.ABCMeta`).