### PR TITLE
Add Transactional pgdbpool Example

### DIFF
--- a/example/03-dbpool/00-create-db.sql
+++ b/example/03-dbpool/00-create-db.sql
@@ -1,0 +1,7 @@
+-- Database: hosting-example
+
+DROP DATABASE IF EXISTS "hosting-example";
+
+CREATE DATABASE "hosting-example"
+    WITH OWNER = postgres ENCODING = 'UTF8';
+

--- a/example/03-dbpool/01-create-schema-sequence.sql
+++ b/example/03-dbpool/01-create-schema-sequence.sql
@@ -1,0 +1,46 @@
+\connect "hosting-example"
+
+-- SCHEMA: sys_core
+
+DROP SCHEMA IF EXISTS sys_core CASCADE;
+
+CREATE SCHEMA IF NOT EXISTS sys_core;
+
+-- SCHEMA: sys_dns
+
+DROP SCHEMA IF EXISTS sys_dns CASCADE;
+
+CREATE SCHEMA IF NOT EXISTS sys_dns;
+
+-- SEQUENCE: sys_core.user_id_seq
+
+DROP SEQUENCE IF EXISTS sys_core."user_id_seq";
+
+CREATE SEQUENCE IF NOT EXISTS sys_core."user_id_seq"
+    INCREMENT 1
+    START 1
+    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    CACHE 1;
+
+-- SEQUENCE: sys_core.domain_id_seq
+
+DROP SEQUENCE IF EXISTS sys_core."domain_id_seq";
+
+CREATE SEQUENCE IF NOT EXISTS sys_core."domain_id_seq"
+    INCREMENT 1
+    START 1
+    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    CACHE 1;
+
+-- SEQUENCE: sys_dns.dnsrecord_id_seq
+
+DROP SEQUENCE IF EXISTS sys_dns."dnsrecord_id_seq";
+
+CREATE SEQUENCE IF NOT EXISTS sys_dns."dnsrecord_id_seq"
+    INCREMENT 1
+    START 1
+    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    CACHE 1;

--- a/example/03-dbpool/02-create-table.sql
+++ b/example/03-dbpool/02-create-table.sql
@@ -1,0 +1,41 @@
+\connect "hosting-example"
+
+-- Table: sys_core.user
+CREATE TABLE IF NOT EXISTS sys_core."user"
+(
+    id bigint NOT NULL DEFAULT nextval('sys_core.user_id_seq'::regclass),
+    name character varying NOT NULL,
+    CONSTRAINT user_pkey PRIMARY KEY (id)
+);
+
+-- Table: sys_core.domain
+CREATE TABLE IF NOT EXISTS sys_core."domain"
+(
+    id bigint NOT NULL DEFAULT nextval('sys_core.domain_id_seq'::regclass),
+    name text NOT NULL,
+    ending character varying,
+    creator_user_id bigint NOT NULL,
+    CONSTRAINT domain_pkey PRIMARY KEY (id),
+    CONSTRAINT admin_user_id_fk FOREIGN KEY (creator_user_id)
+        REFERENCES sys_core."user" (id) MATCH FULL
+        ON UPDATE NO ACTION
+        ON DELETE CASCADE
+);
+
+-- Table: sys_dns.dnsrecord
+CREATE TABLE IF NOT EXISTS sys_dns."dnsrecord"
+(
+    id integer NOT NULL DEFAULT nextval('sys_dns.dnsrecord_id_seq'::regclass),
+    domain_id integer NOT NULL,
+    name character varying(255) NULL,
+    type character varying(10) NOT NULL,
+    content character varying(65535) NOT NULL,
+    ttl integer,
+    prio integer,
+    CONSTRAINT dnsrecord_pkey PRIMARY KEY (id),
+    CONSTRAINT domain_id_fk FOREIGN KEY (domain_id)
+        REFERENCES sys_core.domain (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE CASCADE,
+    CONSTRAINT c_lowercase_name CHECK (name::text = lower(name::text))
+);

--- a/example/03-dbpool/03-create-index.sql
+++ b/example/03-dbpool/03-create-index.sql
@@ -1,0 +1,29 @@
+\connect "hosting-example"
+
+-- Index: domain_name_ending
+DROP INDEX IF EXISTS "sys_core.domain_name_ending";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "sys_core.domain_name_ending"
+    ON sys_core."domain" USING btree
+    (name ASC NULLS LAST, ending ASC NULLS LAST);
+
+-- Index: domain_user_name_ending
+DROP INDEX IF EXISTS "sys_core.domain_user_name_ending_index";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "sys_core.domain_user_name_ending_index"
+    ON sys_core."domain" USING btree
+    (creator_user_id ASC NULLS LAST, name ASC NULLS LAST, ending ASC NULLS LAST);
+
+-- Index: domain_id
+DROP INDEX IF EXISTS "sys_dns.domain_id";
+
+CREATE INDEX IF NOT EXISTS "sys_dns.domain_id"
+    ON sys_dns."dnsrecord" USING btree
+    (domain_id ASC NULLS LAST);
+
+-- Index: nametype_index
+DROP INDEX IF EXISTS "sys_dns.nametype_index";
+
+CREATE INDEX IF NOT EXISTS "sys_dns.nametype_index"
+    ON sys_dns."dnsrecord" USING btree
+    (name ASC NULLS LAST, type ASC NULLS LAST);

--- a/example/03-dbpool/04-insert-user-data.sql
+++ b/example/03-dbpool/04-insert-user-data.sql
@@ -1,0 +1,3 @@
+\connect "hosting-example"
+
+INSERT INTO sys_core."user" ("name") VALUES ('testuser1');

--- a/example/03-dbpool/class_mapping.py
+++ b/example/03-dbpool/class_mapping.py
@@ -1,0 +1,5 @@
+class_mapping = {
+    'User': 'User',
+    'Domain': 'Domain',
+    'Host': 'Host'
+}

--- a/example/03-dbpool/class_reference.py
+++ b/example/03-dbpool/class_reference.py
@@ -1,0 +1,15 @@
+class_reference = {
+    'User': {
+        'property_ref': 'User',
+        'children': {
+            'Domain': {
+                'property_ref': 'Domain',
+                'children': {
+                    'Host': {
+                        'property_ref': 'Host'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/example/03-dbpool/esbconfig.py
+++ b/example/03-dbpool/esbconfig.py
@@ -1,0 +1,7 @@
+import_classes = {
+    'service_implementation': [
+        'User',
+        'Domain',
+        'Host'
+    ]
+}

--- a/example/03-dbpool/main.py
+++ b/example/03-dbpool/main.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python3
+
+from pgdbpool import pool
+from microesb import microesb
+
+from service_properties import service_properties
+from class_reference import class_reference
+from class_mapping import class_mapping
+from service_call_metadata import service_metadata1
+from service_call_metadata import service_metadata2
+from service_call_metadata import service_metadata3
+
+
+class_mapper1 = microesb.ClassMapper(
+    class_references=class_reference,
+    class_mappings=class_mapping,
+    class_properties=service_properties
+)
+
+class_mapper2 = microesb.ClassMapper(
+    class_references=class_reference,
+    class_mappings=class_mapping,
+    class_properties=service_properties
+)
+
+class_mapper3 = microesb.ClassMapper(
+    class_references=class_reference,
+    class_mappings=class_mapping,
+    class_properties=service_properties
+)
+
+
+try:
+    dbconfig = {
+        'db': {
+            'host': '127.0.0.1',
+            'name': 'hosting-example',
+            'user': 'postgres',
+            'pass': 'changeme',
+            'ssl': 'disable',
+            'connect_timeout': 5,
+            'connection_retry_sleep': 1,
+            'query_timeout': 3000,
+            'session_tmp_buffer': 128
+        },
+        'groups': {
+            'hosting': {
+                'connection_count': 3,
+                'autocommit': False
+            }
+        }
+    }
+
+    pool.Connection.init(dbconfig)
+
+except Exception as e:
+    print('DB connection error: {}'.format(e))
+    exit(0)
+
+
+# use pool connection 1
+with pool.Handler('hosting') as dbcon:
+
+    service_metadata1['data'][0]['User']['dbcon'] = dbcon
+
+    microesb.ServiceExecuter().execute(
+        class_mapper=class_mapper1,
+        service_data=service_metadata1
+    )
+
+    dbcon.commit()
+
+# use (next) pool connection 2
+with pool.Handler('hosting') as dbcon:
+
+    service_metadata2['data'][0]['User']['dbcon'] = dbcon
+
+    microesb.ServiceExecuter().execute(
+        class_mapper=class_mapper2,
+        service_data=service_metadata2
+    )
+
+    dbcon.commit()
+
+# use (next) pool connection 3
+with pool.Handler('hosting') as dbcon:
+
+    service_metadata2['data'][0]['User']['dbcon'] = dbcon
+
+    microesb.ServiceExecuter().execute(
+        class_mapper=class_mapper3,
+        service_data=service_metadata2
+    )
+
+    dbcon.commit()

--- a/example/03-dbpool/powerdns/README.md
+++ b/example/03-dbpool/powerdns/README.md
@@ -1,0 +1,9 @@
+# Powerdns PostgreSQL Backend Configuration
+
+The included pdns.conf (PowerDNS) runs pdns daemon with psql (PostgreSQL) backend.
+Given SQL schemas / configuration can be used with **01-hosting-use-case** example.
+
+Running PowerDNS with this configuration makes inserting DNS records directly
+available within the configured IP setup (192.168.100.250 Resolver, 192.168.100.240
+PostgreSQL server).
+

--- a/example/03-dbpool/powerdns/pdns.conf
+++ b/example/03-dbpool/powerdns/pdns.conf
@@ -1,0 +1,52 @@
+config-name=localnet
+control-console=no
+daemon=yes
+default-ttl=3600
+disable-axfr=yes
+distributor-threads=3
+guardian=yes
+local-address=192.168.100.250
+local-port=53
+log-dns-details=no
+loglevel=4
+master=yes
+max-tcp-connections=1000
+negquery-cache-ttl=120
+query-logging=no
+queue-limit=1500
+setgid=pdns
+setuid=pdns
+slave=no
+
+version-string=full
+
+webserver=no
+
+launch=gpgsql
+gpgsql-host=192.168.100.240
+gpgsql-user=pdns
+gpgsql-password=password
+gpgsql-dbname=hosting
+gpgsql-dnssec=no
+gpgsql-prepared-statements=yes
+
+gpgsql-get-all-domains-query=SELECT domains.id, domains.name, records.content, domains.type, domains.master, domains.notified_serial, domains.last_check, domains.account from sys_dns.dnsdomain domains LEFT JOIN sys_dns.dnsrecord records ON records.domain_id=domains.id AND records.type='SOA' AND records.name=domains.name WHERE records.disabled=false OR $1
+gpgsql-any-id-query=SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int FROM sys_dns.dnsrecord records WHERE disabled=false and name=$1 and domain_id=$2
+gpgsql-any-query=SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int FROM sys_dns.dnsrecord records WHERE disabled=false and name=$1
+gpgsql-basic-query=SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int FROM sys_dns.dnsrecord records WHERE disabled=false and type=$1 and name=$2
+gpgsql-clear-domain-metadata-query=DELETE from sys_dns.dnsdomainmetadata domainmetadata where domain_id=(SELECT id from sys_dns.dnsdomain domains where name=$1) and domainmetadata.kind=$2
+gpgsql-delete-zone-query=DELETE from sys_dns.dnsrecord records where domain_id=$1
+gpgsql-get-domain-metadata-query=SELECT content from sys_dns.dnsdomain domains, sys_dns.dnsdomainmetadata domainmetadata where domainmetadata.domain_id=domains.id and name=$1 and domainmetadata.kind=$2
+gpgsql-get-order-after-query=SELECT ordername from sys_dns.dnsrecord records WHERE disabled=false and ordername ~>~ $1 and domain_id=$2 and ordername is not null order by 1 using ~<~ limit 1
+gpgsql-get-order-before-query=SELECT ordername, name from sys_dns.dnsrecord records WHERE disabled=false and ordername ~<=~ $1 and domain_id=$2 and ordername is not null order by 1 using ~>~ limit 1
+gpgsql-id-query=SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int FROM sys_dns.dnsrecord records WHERE disabled=false and type=$1 and name=$2 and domain_id=$3
+gpgsql-info-all-master-query=SELECT domains.id, domains.name, domains.notified_serial, records.content from sys_dns.dnsrecord records join sys_dns.dnsdomain domains on records.name=domains.name where records.type='SOA' and records.disabled=false and domains.type='MASTER'
+gpgsql-info-all-slaves-query=SELECT id,name,master,last_check from sys_dns.dnsdomain domains WHERE type='SLAVE'
+gpgsql-info-zone-query=SELECT id,name,master,last_check,notified_serial,type,account from sys_dns.dnsdomain domains WHERE name=$1
+gpgsql-insert-record-query=INSERT into sys_dns.dnsrecord records (content,ttl,prio,type,domain_id,disabled,name,ordername,auth) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)	
+gpgsql-list-query=SELECT content,ttl,prio,type,domain_id,disabled::int,name,auth::int,ordername FROM sys_dns.dnsrecord WHERE (disabled=false OR $1) and domain_id=$2 order by name, type
+gpgsql-set-domain-metadata-query=INSERT into sys_dns.dnsdomainmetadata domainmetadata (domain_id, kind, content) select id, $1, $2 from sys_dns.dnsdomain domains where name=$3
+gpgsql-supermaster-query=select account from sys_dns.supermaster supermasters where ip=$1 and nameserver=$2
+gpgsql-update-lastcheck-query=UPDATE sys_dns.dnsdomain domains set last_check=$1 where id=$2
+gpgsql-update-serial-query=UPDATE sys_dns.dnsdomain domains set notified_serial=$1 where id=$2
+gpgsql-get-all-domain-metadata-query=SELECT kind, content FROM sys_dns.dnsdomain domains, sys_dns.dnsdomainmetadata domainmetadata WHERE domainmetadata.domain_id=domains.id and name=$1

--- a/example/03-dbpool/service_call_metadata.py
+++ b/example/03-dbpool/service_call_metadata.py
@@ -1,0 +1,98 @@
+service_metadata1 = {
+    'SYSServiceID': 'insertUserDomain',
+    'data': [
+        {
+            'User':
+            {
+                'SYSServiceMethod': 'init',
+                'name': 'testuser1',
+                'Domain': {
+                    'SYSServiceMethod': 'add',
+                    'name': 'testdomain1',
+                    'ending': 'com',
+                    'Host': [
+                        {
+                            'SYSServiceMethod': 'add',
+                            'type': 'MX',
+                            'value': 'mx01.mailserver.com',
+                            'priority': 1
+                        },
+                        {
+                            'SYSServiceMethod': 'add',
+                            'name': 'host1',
+                            'type': 'A',
+                            'value': '5.44.111.165',
+                            'ttl': 36000
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
+service_metadata2 = {
+    'SYSServiceID': 'insertUserDomain',
+    'data': [
+        {
+            'User':
+            {
+                'SYSServiceMethod': 'init',
+                'name': 'testuser1',
+                'Domain': {
+                    'SYSServiceMethod': 'add',
+                    'name': 'testdomain2',
+                    'ending': 'de',
+                    'Host': [
+                        {
+                            'SYSServiceMethod': 'add',
+                            'name': 'bla01',
+                            'type': 'A',
+                            'value': '2.37.51.21',
+                            'ttl': 36000
+                        },
+                        {
+                            'SYSServiceMethod': 'add',
+                            'name': 'bla02',
+                            'type': 'A',
+                            'value': '2.37.51.21',
+                            'ttl': 36000
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
+service_metadata3 = {
+    'SYSServiceID': 'insertUserDomain',
+    'data': [
+        {
+            'User':
+            {
+                'SYSServiceMethod': 'init',
+                'name': 'testuser1',
+                'Domain': {
+                    'SYSServiceMethod': 'add',
+                    'name': 'ola-amigos',
+                    'ending': 'org',
+                    'Host': [
+                        {
+                            'SYSServiceMethod': 'add',
+                            'name': 'amigo1',
+                            'type': 'A',
+                            'value': '145.20.83.4'
+                        },
+                        {
+                            'SYSServiceMethod': 'add',
+                            'name': 'amigo2',
+                            'type': 'A',
+                            'value': '145.20.83.5'
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/example/03-dbpool/service_implementation.py
+++ b/example/03-dbpool/service_implementation.py
@@ -1,0 +1,105 @@
+from microesb import microesb
+
+
+class User(microesb.ClassHandler):
+
+    def __init__(self):
+        super().__init__()
+        self.DB_user_id = None
+
+    def init(self):
+        crs = self.dbcon.query("""
+            SELECT id
+                FROM sys_core."user"
+            WHERE
+                "name" = %s""",
+            (self.name,)
+        )
+        row = crs.fetchone()
+        self.DB_user_id = row[0]
+
+
+class Domain(microesb.ClassHandler):
+
+    def __init__(self):
+        super().__init__()
+        self.DB_domain_id = None
+
+    def add(self):
+
+        self.DB_user_id = self.parent_object.DB_user_id
+        self.dbcon = self.parent_object.dbcon
+        print("DB_user_id:{} name:{} ending:{}".format(
+            self.DB_user_id, self.name, self.ending)
+        )
+
+        print("Insert Domain")
+
+        crs = self.dbcon.query("""
+            SELECT id
+                FROM sys_core."domain"
+            WHERE
+                creator_user_id = %s AND "name" = %s AND ending = %s""",
+            (self.DB_user_id, self.name, self.ending,)
+        )
+        try:
+            row = crs.fetchone()
+            self.DB_domain_id = row[0]
+        except Exception as e:
+            pass
+
+        print("DB_domain_id:{}".format(self.DB_domain_id))
+
+        crs = self.dbcon.query("""
+            INSERT INTO sys_core."domain"
+                (creator_user_id, "name", ending)
+            VALUES
+                (%s, %s, %s)
+            ON CONFLICT (creator_user_id, "name", ending) DO NOTHING
+            RETURNING id
+            """,
+            (self.DB_user_id, self.name, self.ending)
+        )
+        try:
+            row = crs.fetchone()
+            self.DB_domain_id = row[0]
+        except Exception as e:
+            pass
+
+
+class Host(microesb.MultiClassHandler):
+
+    def __init__(self):
+        super().__init__()
+        self.name = None
+        self.priority = None
+        self.ttl = None
+
+    def add(self):
+        self.dbcon = self.parent_object.dbcon
+        self.DB_user_id = self.parent_object.DB_user_id
+        self.DB_domain_id = self.parent_object.DB_domain_id
+
+        print("Host add() called")
+
+        print("DB_user_id:{} DB_domain_id:{}".format(
+            self.DB_user_id, self.DB_domain_id)
+        )
+
+        try:
+            self.dbcon.query("""
+                INSERT INTO sys_dns."dnsrecord"
+                    (domain_id, "name", "type", content, ttl, prio)
+                VALUES
+                    (%s, %s, %s, %s, %s, %s)""",
+                (
+                    self.DB_domain_id,
+                    self.name,
+                    self.type,
+                    self.value,
+                    self.ttl,
+                    self.priority
+                )
+            )
+        except Exception as e:
+            print("Insert exception:{}".format(e))

--- a/example/03-dbpool/service_properties.py
+++ b/example/03-dbpool/service_properties.py
@@ -1,0 +1,71 @@
+service_properties = {
+    'User': {
+        'properties': {
+            'name': {
+                'type': 'str',
+                'default': None,
+                'required': True,
+                'description': 'Textual UserID'
+            },
+            'dbcon': {
+                'type': 'classref',
+                'default': None,
+                'required': True,
+                'description': 'Database Connection Ref'
+            }
+        },
+        'methods': ['init']
+    },
+    'Domain': {
+        'properties': {
+            'name': {
+                'type': 'str',
+                'default': None,
+                'required': True,
+                'description': 'Domain Name'
+            },
+            'ending': {
+                'type': 'str',
+                'default': None,
+                'required': True,
+                'description': 'Domain Ending'
+            }
+        },
+        'methods': ['add', 'delete']
+    },
+    'Host': {
+        'properties': {
+            'name': {
+                'type': 'str',
+                'default': None,
+                'required': False,
+                'description': 'DNS Name'
+            },
+            'type': {
+                'type': 'str',
+                'default': None,
+                'required': True,
+                'description': 'DNS Type'
+            },
+            'value': {
+                'type': 'str',
+                'default': None,
+                'required': True,
+                'description': 'DNS Value'
+            },
+            'ttl': {
+                'type': 'int',
+                'default': 3600,
+                'required': False,
+                'description': 'DNS Time To Live'
+            },
+            'priority': {
+                'type': 'int',
+                'default': None,
+                'required': False,
+                'description': 'MX Type Priority'
+            }
+        },
+        'methods': ['add', 'update', 'delete']
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

Add an transactional database (Autocommit=False) example (example03) using https://github.com/clauspruefer/python-dbpool.

The example proves the correct **microesb** / **pgdbpool** behaviour on multiple serial database transactions.
Somehow Apache/WSGI misbehaves in global static data definitions on which **microesb** relies on.

## Related Issue

https://github.com/WEBcodeX1/x0-skeleton/issues/37

## Type of Change

- [x] Example / Howto
- [x] External Library

## Additional Notes

To guarantee stable database handling using **microesb**, *x0-system* must switch to **falcon-as** fastly.
