### PR TITLE
Fix (Use copy.deepcopy) Example03

### DIFF
--- a/example/03-dbpool/main.py
+++ b/example/03-dbpool/main.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+import copy
+
 from pgdbpool import pool
 from microesb import microesb
 
@@ -42,7 +44,7 @@ except Exception as e:
 # first pool connection 1
 
 class_mapper_ref = microesb.ClassMapper(
-    class_references=class_reference,
+    class_references=copy.deepcopy(class_reference),
     class_mappings=class_mapping,
     class_properties=service_properties
 )
@@ -61,7 +63,7 @@ with pool.Handler('hosting') as dbcon:
 # use (next) pool connection 2
 
 class_mapper_ref = microesb.ClassMapper(
-    class_references=class_reference,
+    class_references=copy.deepcopy(class_reference),
     class_mappings=class_mapping,
     class_properties=service_properties
 )
@@ -80,7 +82,7 @@ with pool.Handler('hosting') as dbcon:
 # use (next) pool connection 3
 
 class_mapper_ref = microesb.ClassMapper(
-    class_references=class_reference,
+    class_references=copy.deepcopy(class_reference),
     class_mappings=class_mapping,
     class_properties=service_properties
 )


### PR DESCRIPTION
# Pull Request

## Description

Fix example03 by using `copy.deepcopy`.
One single **static** microesb.ClassMapper() call overwrites (global referenced) `class_reference` variable content. A  `copy.deepcopy` call prevents this behaviour.

## Related Issue

Closes #18.

## Type of Change

- [x] Bug fix

## Additional Notes

This also *should* fix x0-skeleton example01 https://github.com/WEBcodeX1/x0-skeleton/tree/main/example/01-forms-microesb.
