### PR TITLE
Add Updated Roadmap (From DB ORM to noSQL ODM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Our interpretation of what an ESB should consist of:
 - ✅ Centralized Service / API Registry containing clean XML, JSON Model
 - ✅ Centralized Service AAA (Authentication / Authorization / Accounting)
 - ✅ Internal Service XML / (Python) Class Mapping
-- ✅ OOP Relational Database Mapper
+- ✅ Relational Backend OOP / ORM / ODM Mapper
 - ✅ Service Model Documentation / API (Auto)-Generation
 
 ## 3. Install
@@ -55,7 +55,7 @@ Building web applications on PaaS infrastructure also relies on a clean Service 
 
 ### 5.1. In Progress
 
-- :hourglass: OOP Relational Database Mapper
+- :hourglass: OOP Relational ODM Mapper (MongoDB)
 - :hourglass: Service Documentation (Auto)-Generation
 
 ## 6. Documentation / Examples


### PR DESCRIPTION
# Pull Request

## Description
Update roadmap (switch from SQL Database ORM management to noSQL ODM).

## Why
- Automatic ORM processing / generating SQL queries in dependend transactional DB processing could be contraproductive
- Single SQL management in current MicroESB class hierarchical design is much simpler
- ODM JSON can be built easily in current MicroESB class hierarchical design
- ODM JSON does fit much better in modern web-application design / `x0-framework` structure

## Type of Change

- [x] Stratecic Update
- [x] Documentation update

## Additional Notes

Diagram(s) describing an optimal ODM workflow in combination with x0-framework will follow ASAP.